### PR TITLE
Add compatibility mode to cereal golden tests

### DIFF
--- a/src/Test/Cereal/GenericSpecs.hs
+++ b/src/Test/Cereal/GenericSpecs.hs
@@ -78,7 +78,7 @@ roundtripSpecs Proxy = Roundtrip.roundtripSpecs (Proxy :: Proxy (GoldenCereal a)
 -- to help monitor changes.
 goldenSpecs ::
   forall a.
-  (Arbitrary a, Cereal.Serialize a, Typeable a, Show a) =>
+  (Arbitrary a, Cereal.Serialize a, Typeable a, Show a, Eq a) =>
   Settings ->
   Proxy a ->
   Spec

--- a/src/Test/Cereal/Internal/Utils.hs
+++ b/src/Test/Cereal/Internal/Utils.hs
@@ -62,7 +62,7 @@ data Settings = Settings
     fileType :: String
   }
 
-type GoldenSerializerConstraints s a = (GoldenSerializer s, Ctx s (RandomSamples a))
+type GoldenSerializerConstraints s a = (GoldenSerializer s, Ctx s (RandomSamples a), Show a, Eq a)
 
 class GoldenSerializer s where
   type Ctx s :: * -> Constraint
@@ -189,3 +189,7 @@ createMissingGoldenEnv = "CREATE_MISSING_GOLDEN"
 
 recreateBrokenGoldenEnv :: String
 recreateBrokenGoldenEnv = "RECREATE_BROKEN_GOLDEN"
+
+-- | env variable that is used in CI, indicates whether we golden test byte for byte
+compatibilityCheckEnv :: String 
+compatibilityCheckEnv = "COMPATIBILITY_CHECK"


### PR DESCRIPTION
## Related Issue
https://github.com/plow-technologies/all/issues/9995


According to the spec:

### hspec-golden: Assertions - Compatibility check

Recent changes trigger us the idea of needing both; Assertions that are able to determine if golden files are changed or not, and assertions that are able to determine if backwards (or forward) compatibility is preserve.

As those assertions can’t happen simultaneously, we want to introduce the `COMPATIBILITY_CHECK` flag for `roundtripAndGolden` method in order to just run compatibility check and not other checks.

```
typeA <- decode serialA
serialA_new <- encode typeA
typeA_new <- decode serialA_new
compare typeA typeA_new
```
^  type compatibility check is a simplify version of the historical approach (remains allowing backward and forward compatibility checks).

About_ x86-arm64: 

Doing the byte-wise checking for arm and x86 produce different bytes, So for those cases, we should just ensure compatibility checks only.
