### PR TITLE
Introduce COMPATIBILITY_CHECK mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for hspec-golden-cereal
 
+## 0.4.0.0  -- 2023-01-03
+* Introduce COMPATIBILITY_CHECK mode
+
 ## 0.3.0.0  -- 2022-12-16
 * Remove roundtripFromFile, but re use their code in order to fix goldenSpecs
 
@@ -7,5 +10,4 @@
 * Add roundtripFromFile. Run golden tests without using the Arbitrary instance. Will decode the golden file and test if the encoding function is equivalent to the golden file 
 
 ## 0.1.0.0  -- 2021-04-11
-
 * First version adapted from hspec-golden-aeson. 

--- a/hspec-golden-cereal.cabal
+++ b/hspec-golden-cereal.cabal
@@ -59,7 +59,7 @@ test-suite test
       Test.Cereal.GenericSpecsSpec
       Test.Types
       Test.Types.AlteredSelector
-      Test.Types.BrokenSerialization
+      Test.Types.BackwardCompatible
       Test.Types.MismatchedToAndFromSerialization
       Test.Types.NewSelector
       Test.Utils

--- a/hspec-golden-cereal.cabal
+++ b/hspec-golden-cereal.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hspec-golden-cereal
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Use tests to monitor changes in Cereal serialization
 description:    Use tests to monitor changes in Cereal serialization
 category:       Testing

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-golden-cereal
-version: 0.2.0.0
+version: 0.4.0.0
 synopsis: Use tests to monitor changes in Cereal serialization
 description: Use tests to monitor changes in Cereal serialization
 category: Testing

--- a/src/Test/Cereal/GenericSpecs.hs
+++ b/src/Test/Cereal/GenericSpecs.hs
@@ -78,7 +78,7 @@ roundtripSpecs Proxy = Roundtrip.roundtripSpecs (Proxy :: Proxy (GoldenCereal a)
 -- to help monitor changes.
 goldenSpecs ::
   forall a.
-  (Arbitrary a, Cereal.Serialize a, Typeable a, Show a) =>
+  (Arbitrary a, Cereal.Serialize a, Typeable a, Show a, Eq a) =>
   Settings ->
   Proxy a ->
   Spec

--- a/src/Test/Cereal/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Cereal/Internal/ADT/GoldenSpecs.hs
@@ -125,7 +125,7 @@ testConstructor Settings {..} moduleName typeName cap =
 --   then compare both encoded representations (byte for byte check).
 compareWithGolden ::
   forall a.
-  (Show a, Eq a, Serialize a, ToADTArbitrary a) =>
+  (Eq a, Serialize a, ToADTArbitrary a) =>
   String ->
   Maybe String ->
   String ->

--- a/src/Test/Cereal/Internal/Utils.hs
+++ b/src/Test/Cereal/Internal/Utils.hs
@@ -62,7 +62,7 @@ data Settings = Settings
     fileType :: String
   }
 
-type GoldenSerializerConstraints s a = (GoldenSerializer s, Ctx s (RandomSamples a))
+type GoldenSerializerConstraints s a = (GoldenSerializer s, Ctx s (RandomSamples a), Show a, Eq a)
 
 class GoldenSerializer s where
   type Ctx s :: * -> Constraint
@@ -189,3 +189,7 @@ createMissingGoldenEnv = "CREATE_MISSING_GOLDEN"
 
 recreateBrokenGoldenEnv :: String
 recreateBrokenGoldenEnv = "RECREATE_BROKEN_GOLDEN"
+
+-- | env variable that is used in CI, indicates whether we golden test byte for byte
+compatibilityCheckEnv :: String 
+compatibilityCheckEnv = "COMPATIBILITY_CHECK"

--- a/test/Test/Cereal/GenericSpecsSpec.hs
+++ b/test/Test/Cereal/GenericSpecsSpec.hs
@@ -125,9 +125,10 @@ spec = before unsetAllEnv $ do
         goldenSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    it "goldenSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
-      setCompatibilityCheckEnv
-      shouldProduceFailures 0 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+    -- FIXME: This test is broken, but I'm not sure if TBC.Person is backward compatible or not!
+    --it "goldenSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+    --  setCompatibilityCheckEnv
+    --  shouldProduceFailures 0 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
       setCompatibilityCheckEnv
@@ -209,9 +210,10 @@ spec = before unsetAllEnv $ do
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    it "goldenADTSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
-      setCompatibilityCheckEnv
-      shouldProduceFailures 0 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+    -- FIXME: This test is broken, but I'm not sure if TBC.Person is backward compatible or not!
+    -- it "goldenADTSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+    --   setCompatibilityCheckEnv
+    --   shouldProduceFailures 0 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenADTSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
       setCompatibilityCheckEnv

--- a/test/Test/Cereal/GenericSpecsSpec.hs
+++ b/test/Test/Cereal/GenericSpecsSpec.hs
@@ -125,10 +125,9 @@ spec = before unsetAllEnv $ do
         goldenSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    -- FIXME: This test is broken, but I'm not sure if TBC.Person is backward compatible or not!
-    --it "goldenSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
-    --  setCompatibilityCheckEnv
-    --  shouldProduceFailures 0 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+    it "goldenSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 0 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
       setCompatibilityCheckEnv
@@ -210,10 +209,9 @@ spec = before unsetAllEnv $ do
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    -- FIXME: This test is broken, but I'm not sure if TBC.Person is backward compatible or not!
-    -- it "goldenADTSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
-    --   setCompatibilityCheckEnv
-    --   shouldProduceFailures 0 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+    it "goldenADTSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 0 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenADTSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
       setCompatibilityCheckEnv

--- a/test/Test/Types.hs
+++ b/test/Test/Types.hs
@@ -13,7 +13,16 @@ data Person = Person
   }
   deriving (Eq, Show, Generic)
 
-instance Serialize Person
+instance Serialize Person where
+  put x = do
+    putWord16le 0
+    put $ name x
+    put $ age x
+  get = do
+    v <- getWord16le
+    case v of
+      0 -> Person <$> get <*> get
+      _ -> fail $ "Unknown version: " ++ show v
 
 instance ToADTArbitrary Person
 

--- a/test/Test/Types/BackwardCompatible.hs
+++ b/test/Test/Types/BackwardCompatible.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Types.BrokenSerialization where
+module Test.Types.BackwardCompatible where
 
 import Data.Serialize
 import GHC.Generics
@@ -28,24 +28,7 @@ instance Serialize Person where
     PersonWithoutAge n <- get
     return $ Person n 0 
 
-
 instance ToADTArbitrary Person
 
 instance Arbitrary Person where
   arbitrary = genericArbitrary
-
-data SumType
-  = SumType1 Int
-  | SumType2 String Int
-  | SumType3 Double String Int
-  deriving (Eq, Show, Generic)
-
-instance Serialize SumType
-
-instance ToADTArbitrary SumType
-
-instance Arbitrary SumType where
-  arbitrary = genericArbitrary
-
-data P2 = P2 String Int deriving (Eq, Show, Generic)
-instance Serialize P2


### PR DESCRIPTION
## Related Issue
https://github.com/plow-technologies/all/issues/9995


According to the spec:

### hspec-golden: Assertions - Compatibility check

Recent changes trigger us the idea of needing both; Assertions that are able to determine if golden files are changed or not, and assertions that are able to determine if backwards (or forward) compatibility is preserve.

As those assertions can’t happen simultaneously, we want to introduce the `COMPATIBILITY_CHECK` flag for `roundtripAndGolden` method in order to just run compatibility check and not other checks.

```
typeA <- decode serialA
serialA_new <- encode typeA
typeA_new <- decode serialA_new
compare typeA typeA_new
```
^  type compatibility check is a simplify version of the historical approach (remains allowing backward and forward compatibility checks).

About_ x86-arm64: 

Doing the byte-wise checking for arm and x86 produce different bytes, So for those cases, we should just ensure compatibility checks only.
